### PR TITLE
Fix ConfigEntry runtime_data

### DIFF
--- a/custom_components/hive/__init__.py
+++ b/custom_components/hive/__init__.py
@@ -78,6 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     web_session = aiohttp_client.async_get_clientsession(hass)
     hive_config = dict(entry.data)
     hive = Hive(web_session)
+    entry.runtime_data = hive
 
     hive_config["options"] = {}
     hive_config["options"].update(


### PR DESCRIPTION
## Summary
- set `entry.runtime_data` when setting up the Hive config entry

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684af256b2748320b6d73de55d52f8c5